### PR TITLE
Trigger an event after dynamic resize operation is performed

### DIFF
--- a/app/js/app-utilities.js
+++ b/app/js/app-utilities.js
@@ -798,6 +798,9 @@ appUtilities.dynamicResize = function () {
     $("#network-panels-container, .network-panel").height(windowHeight * 0.85);
     $("#sbgn-inspector").height(windowHeight * 0.85);
   }
+
+  // trigger an event to notify that newt components are dynamically resized
+  $(document).trigger('newtAfterDynamicResize');
 };
 /*
 appUtilities.nodeQtipFunction = function (node) {


### PR DESCRIPTION
Triggered ```newtAfterDynamicResize``` event at the end of ```appUtilities.dynamicResize()``` function to notify that newt components are dynamically resized. This is especially needed by the collaborative platform because it has different html components then newt and these components should be dynamically resized when newt components are resized.