### PR TITLE
Let network panels fill their parent instead of setting their size in dynamic resize

### DIFF
--- a/app/css/chise.css
+++ b/app/css/chise.css
@@ -185,8 +185,8 @@ body {
 }
 
 .network-panel {
-  height: 680px;
-  width: 800px;
+  height: 100%;
+  width: 100%;
 }
 
 #network-tabs-list-container {

--- a/app/js/app-menu.js
+++ b/app/js/app-menu.js
@@ -47,7 +47,7 @@ module.exports = function() {
 
   $(window).on('resize', _.debounce(dynamicResize, 100));
 
-  // appUtilities.dynamicResize();
+  dynamicResize();
 
   layoutPropertiesView = appUtilities.layoutPropertiesView = new BackboneViews.LayoutPropertiesView({el: '#layout-properties-table'});
   colorSchemeInspectorView = appUtilities.colorSchemeInspectorView = new BackboneViews.ColorSchemeInspectorView({el: '#color-scheme-template-container'});

--- a/app/js/app-utilities.js
+++ b/app/js/app-utilities.js
@@ -427,9 +427,6 @@ appUtilities.createNewNetwork = function () {
   // physically open the new tab
   appUtilities.chooseNetworkTab(appUtilities.nextNetworkId);
 
-  // resize html components according to the window size
-  appUtilities.dynamicResize();
-
   // activate palette tab
   if (!$('#inspector-palette-tab').hasClass('active')) {
     $('#inspector-palette-tab a').tab('show');
@@ -783,7 +780,7 @@ appUtilities.dynamicResize = function () {
     //This is the margin on left and right of the main content when the page is
     //displayed
     var mainContentMargin = 10;
-    $("#network-panels-container, .network-panel").width(windowWidth  * 0.8 - mainContentMargin);
+    $("#network-panels-container").width(windowWidth  * 0.8 - mainContentMargin);
     $("#sbgn-inspector").width(windowWidth  * 0.2 - mainContentMargin);
     var w = $("#sbgn-inspector-and-canvas").width();
     $(".nav-menu").width(w);
@@ -795,7 +792,7 @@ appUtilities.dynamicResize = function () {
 
   if (windowHeight > canvasHeight)
   {
-    $("#network-panels-container, .network-panel").height(windowHeight * 0.85);
+    $("#network-panels-container").height(windowHeight * 0.85);
     $("#sbgn-inspector").height(windowHeight * 0.85);
   }
 };


### PR DESCRIPTION
For each network/tab is an html div is created. All of these divs are children of a parent div(network-panels-container). Size of these divs were defined as the same of their parent and they were adjusted in ```appUtilities.dynamicResize()```. Instead of doing so setting their size as 100% and so  not needing to adjust their size in ```appUtilities.dynamicResize()``` would be a better and safer. In this way we do not need to call ```appUtilities.dynamicResize()``` when a new tab is created.