### PR TITLE
Update inspectors object tab when active tab is changed 

### DIFF
--- a/app/js/app-menu.js
+++ b/app/js/app-menu.js
@@ -1183,6 +1183,7 @@ module.exports = function() {
       var target = $(e.target).attr("href"); // activated tab
       console.log(target);
       appUtilities.setActiveNetwork(target);
+      inspectorUtilities.handleSBGNInspector();
     });
   }
 };


### PR DESCRIPTION
To re-solve #286
I would like to call ``inspectorUtilities.handleSBGNInspector()`` from ``appUtilities.setActiveNetwork()`` but that was not possible since requiring ``inspectorUtilities`` from ``appUtilities`` causes circular require. 
Therefore, I called it from the code segment where tab change is listened to right after ``appUtilities.setActiveNetwork()`` is called. However, it must be functioning in the same way.