### PR TITLE
Highlight color and thickness feature added

### DIFF
--- a/app/js/app-undo-actions-factory.js
+++ b/app/js/app-undo-actions-factory.js
@@ -356,7 +356,20 @@ module.exports = function (cy) {
 
     };
    
-   
+   if (id == "highlight-color" || id == "highlight-thickness") {
+    var viewUtilities = cy.viewUtilities('get');
+    var highlightColor = $('#highlight-color').val();
+    var highlightThickness = Number($('#highlight-thickness').val());
+
+    viewUtilities.changeHighlightStyle(0, {
+      'border-width' : highlightThickness, 'border-color': highlightColor
+    }, {
+      'width': highlightThickness,
+      'line-color': highlightColor,
+      'source-arrow-color': highlightColor,
+      'target-arrow-color': highlightColor
+    });
+   }
 
     return result;
   }

--- a/app/js/app-utilities.js
+++ b/app/js/app-utilities.js
@@ -412,7 +412,9 @@ appUtilities.createNewNetwork = function () {
     undoable: appUtilities.undoable,
     undoableDrag: function() {
       return appUtilities.ctrlKeyDown !== true;
-    }
+    },
+    highlightColor: currentGeneralProperties.highlightColor,
+    highlightThickness: currentGeneralProperties.highlightThickness 
   });
   
   // set scracth pad of the related cy instance with these properties
@@ -754,7 +756,9 @@ appUtilities.defaultGeneralProperties = {
   mapType: function() {return (appUtilities.getActiveChiseInstance().getMapType() || "Unknown");},
   mapName: "",
   mapDescription: "",
-  experimentDescription: ""
+  experimentDescription: "",
+  highlightColor: '#0B9BCD', //the color code used when initializing viewUtilities in app-cy.js
+  highlightThickness: 3
 };
 
 appUtilities.setFileContent = function (fileName) {
@@ -2417,7 +2421,24 @@ appUtilities.setMapProperties = function(mapProperties, _chiseInstance) {
     chiseInstance.refreshPaddings(); // Refresh/recalculate paddings
 
     cy.edges().css('arrow-scale', currentGeneralProperties.arrowScale);
-    
+
+    //setMapProperties function is called in sbgnvizLoadFileEnd sbgnvizLoadSampleEnd 
+    //event handler
+    if ('highlightColor' in mapProperties && 'highlightThickness' in mapProperties) {
+      var viewUtilities = cy.viewUtilities('get');
+      var highlightColor = currentGeneralProperties.highlightColor[0];
+      var highlightThickness = currentGeneralProperties.highlightThickness;
+
+      viewUtilities.changeHighlightStyle(0, {
+        'border-width': highlightThickness, 'border-color': highlightColor
+      }, {
+        'width': highlightThickness,
+        'line-color': highlightColor,
+        'source-arrow-color': highlightColor,
+        'target-arrow-color': highlightColor
+    });
+    }
+
     if (currentGeneralProperties.enablePorts) {
       chiseInstance.enablePorts();
     }

--- a/app/js/backbone-views.js
+++ b/app/js/backbone-views.js
@@ -547,6 +547,11 @@ var MapTabGeneralPanel = GeneralPropertiesParentView.extend({
     self.params.mapDescription = {id: "map-description", type: "text",
       property: "currentGeneralProperties.mapDescription"};
 
+    self.params.highlightThickness = {id: "highlight-thickness", type: "range",
+      property: "currentGeneralProperties.highlightThickness"};  
+
+    self.params.highlightColor = {id: "highlight-color", type: "color",
+      property: "currentGeneralProperties.highlightColor"};
    
     // general properties part
     $(document).on("change", "#map-name", function (evt) {
@@ -782,6 +787,44 @@ var MapTabGeneralPanel = GeneralPropertiesParentView.extend({
       $('#enable-sif-topology-grouping').blur();
     });
 
+    $(document).on("change", "#highlight-thickness", function(evt) {
+      var cy = appUtilities.getActiveCy();
+      var viewUtilities = cy.viewUtilities('get');
+      self.params.highlightThickness.value = Number($('#highlight-thickness').val());
+      var highlightThickness = self.params.highlightThickness.value;
+      var highlightColor = self.params.highlightColor.value;
+      
+      viewUtilities.changeHighlightStyle(0, {
+        'border-width': highlightThickness, 'border-color': highlightColor
+      }, {
+        'width': highlightThickness,
+        'line-color': highlightColor,
+        'source-arrow-color': highlightColor,
+        'target-arrow-color': highlightColor
+      });
+      cy.undoRedo().do("changeMenu", self.params.highlightThickness);
+      $('#highlight-thickness').blur();
+    });
+
+    $(document).on("change", "#highlight-color", function(evt) {
+      var cy = appUtilities.getActiveCy();
+      var viewUtilities = cy.viewUtilities('get');
+      self.params.highlightColor.value = $('#highlight-color').val();
+      var highlightThickness = self.params.highlightThickness.value;
+      var highlightColor = self.params.highlightColor.value;
+
+      viewUtilities.changeHighlightStyle(0, {
+        'border-width' : highlightThickness, 'border-color': highlightColor
+      }, {
+        'width': highlightThickness,
+        'line-color': highlightColor,
+        'source-arrow-color': highlightColor,
+        'target-arrow-color': highlightColor
+      });
+      cy.undoRedo().do("changeMenu", self.params.highlightColor);
+      $('#highlight-color').blur();
+    });
+
     $(document).on("click", "#inspector-map-tab", function (evt) {
       var chiseInstance = appUtilities.getActiveChiseInstance();
       //document.getElementById('map-type').value = chiseInstance.getMapType() ? chiseInstance.getMapType() : "Unknown";
@@ -806,6 +849,8 @@ var MapTabGeneralPanel = GeneralPropertiesParentView.extend({
       self.params.enableSIFTopologyGrouping.value = appUtilities.defaultGeneralProperties.enableSIFTopologyGrouping;
       self.params.compoundPadding.value = appUtilities.defaultGeneralProperties.compoundPadding;
       self.params.arrowScale.value = appUtilities.defaultGeneralProperties.arrowScale;
+      self.params.highlightThickness.value = appUtilities.defaultGeneralProperties.highlightThickness;
+      self.params.highlightColor.value = appUtilities.defaultGeneralProperties.highlightColor;
       actions.push({name: "changeMenu", param: self.params.allowCompoundNodeResize});
       actions.push({name: "changeMenu", param: self.params.inferNestingOnLoad});
       actions.push({name: "changeMenu", param: self.params.enablePorts});
@@ -815,6 +860,8 @@ var MapTabGeneralPanel = GeneralPropertiesParentView.extend({
       actions.push({name: "changeMenu", param: self.params.arrowScale});
       actions.push({name: "changeCss", param: { eles: cy.edges(), name: "arrow-scale",
           valueMap: self.params.arrowScale.value}});
+      actions.push({name: "changeMenu", param: self.params.highlightThickness});
+      actions.push({name: "changeMenu", param: self.params.highlightColor});
       ur.do("batch", actions);
     });
   },

--- a/index.html
+++ b/index.html
@@ -1314,6 +1314,17 @@
             </td>
             </tr>
 
+            <tr>
+            <td class="header">
+            <span class="add-on layout-text" title="Highlight thickness and color">Highlight Style</span>
+            </td>
+
+            <td>
+            <input id="highlight-thickness"  type='range' class="sbgn-input-small" style="display:inline;vertical-align:top" step='0.5' min='1' max='10' value= <%= highlightThickness %>>
+            <input id="highlight-color" type="color" class="inspector-input-box" value= <%= highlightColor %>>
+            </td>
+            </tr>
+
             </tbody>
             </table>
 


### PR DESCRIPTION
Highlight color and thickness can be adjusted via "Map" tab, under "General" panel, at the bottom; through a slider for thickness and a color picker for color. 

Additionally, highlight thickness and color data are written to `.nwt` map files and `.newtp` preference files, under `<mapProperties>` tag and `currentGeneralProperties` field, respectively. 

The functionality is also compatible with undo-redo and changing settings to default.   